### PR TITLE
Use ProgramFiles6432Folder for default install location

### DIFF
--- a/src/wixlib/WixUI_Advanced.wxs
+++ b/src/wixlib/WixUI_Advanced.wxs
@@ -29,7 +29,7 @@ Todo:
         <PropertyRef Id="ApplicationFolderName" />
 
         <CustomAction Id="WixSetDefaultPerUserFolder" Property="WixPerUserFolder" Value="[LocalAppDataFolder]Apps\[ApplicationFolderName]" Execute="immediate" />
-        <CustomAction Id="WixSetDefaultPerMachineFolder" Property="WixPerMachineFolder" Value="[ProgramFilesFolder][ApplicationFolderName]" Execute="immediate" />
+        <CustomAction Id="WixSetDefaultPerMachineFolder" Property="WixPerMachineFolder" Value="[ProgramFiles6432Folder][ApplicationFolderName]" Execute="immediate" />
         <CustomAction Id="WixSetPerUserFolder" Property="APPLICATIONFOLDER" Value="[WixPerUserFolder]" Execute="immediate" />
         <CustomAction Id="WixSetPerMachineFolder" Property="APPLICATIONFOLDER" Value="[WixPerMachineFolder]" Execute="immediate" />
 


### PR DESCRIPTION
I was using Wix_Advanced but the default installation directory is in `Program Files(x86)`, this should fix it.